### PR TITLE
Update PinchZoomImagePlugin.kt

### DIFF
--- a/android/src/main/kotlin/com/shatsy/pinchzoomimage/PinchZoomImagePlugin.kt
+++ b/android/src/main/kotlin/com/shatsy/pinchzoomimage/PinchZoomImagePlugin.kt
@@ -15,7 +15,9 @@ class PinchZoomImagePlugin(private val activity: Activity) : MethodCallHandler {
     @JvmStatic
     fun registerWith(registrar: Registrar) {
       val channel = MethodChannel(registrar.messenger(), "pinch_zoom_image")
-      channel.setMethodCallHandler(PinchZoomImagePlugin(registrar.activity()))
+      if(registrar.activity() != null){ //Guard necessary for headless implementation 
+        channel.setMethodCallHandler(PinchZoomImagePlugin(registrar.activity()))
+      }
     }
   }
 


### PR DESCRIPTION
Guard Conditional is needed to prevent the app from crashing when headless mode is used.